### PR TITLE
Fix Attack of the Clones cast typo

### DIFF
--- a/src/prequel_trilogy.html
+++ b/src/prequel_trilogy.html
@@ -140,7 +140,7 @@
                     <td>George Lucas</td>
                     <td>
                       Hayden Christensen, Natalie Portman, Ewan McGregor,
-                      Chistopher Lee, Samuel L. Jackson, Ian McDiarmid
+                      Christopher Lee, Samuel L. Jackson, Ian McDiarmid
                     </td>
                   </tr>
                   <tr>


### PR DESCRIPTION
## Summary
- correct spelling of Christopher Lee in prequel trilogy table

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683fd32682048332acffca8722c8968b